### PR TITLE
TypeScript suggestions

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,62 +2,10 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import makeCancellable from 'make-cancellable-promise';
 
-// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
-// A more precise version of just React.ComponentPropsWithoutRef on its own
-export type PropsOf<C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>> =
-  JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
-
-type AsProp<C extends React.ElementType> = {
-  /**
-   * An override of the default HTML tag.
-   * Can also be another React component.
-   */
-  as?: C;
-};
-
-/**
- * Allows for extending a set of props (`ExtendedProps`) by an overriding set of props
- * (`OverrideProps`), ensuring that any duplicates are overridden by the overriding
- * set of props.
- */
-export type ExtendableProps<ExtendedProps = unknown, OverrideProps = unknown> = OverrideProps &
-  Omit<ExtendedProps, keyof OverrideProps>;
-
-/**
- * Allows for inheriting the props from the specified element type so that
- * props like children, className & style work, as well as element-specific
- * attributes like aria roles. The component (`C`) must be passed in.
- */
-export type InheritableElementProps<C extends React.ElementType, Props = unknown> = ExtendableProps<
-  PropsOf<C>,
-  Props
->;
-
-/**
- * A more sophisticated version of `InheritableElementProps` where
- * the passed in `as` prop will determine which props can be included
- */
-export type PolymorphicComponentProps<
-  C extends React.ElementType,
-  Props = unknown,
-> = InheritableElementProps<C, Props & AsProp<C>>;
-
-/**
- * Utility type to extract the `ref` prop from a polymorphic component
- */
-export type PolymorphicRef<C extends React.ElementType> = React.ComponentPropsWithRef<C>['ref'];
-/**
- * A wrapper of `PolymorphicComponentProps` that also includes the `ref`
- * prop for the polymorphic component
- */
-export type PolymorphicComponentPropsWithRef<
-  C extends React.ElementType,
-  Props = unknown,
-> = PolymorphicComponentProps<C, Props> & { ref?: PolymorphicRef<C> };
-
 type Config<T extends React.ElementType> = React.ComponentPropsWithoutRef<T>;
 
-type Props<T extends React.ElementType> = {
+type AsyncButtonProps<T extends React.ElementType> = {
+  as?: T;
   errorConfig?: Config<T>;
   onClick?: (event: React.MouseEvent) => void | Promise<void>;
   pendingConfig?: Config<T>;
@@ -65,10 +13,7 @@ type Props<T extends React.ElementType> = {
   successConfig?: Config<T>;
 } & Config<T>;
 
-type AsyncButtonProps<C extends React.ElementType = 'button'> = PolymorphicComponentPropsWithRef<
-  C,
-  Props<C>
->;
+type PolymorphicRef<C extends React.ElementType> = React.ComponentPropsWithRef<C>['ref'];
 
 const STATES = {
   ERROR: 'error',
@@ -192,6 +137,6 @@ AsyncButton.propTypes = {
   successConfig: isConfigObject,
 };
 
-export default AsyncButton as <T extends React.ElementType>(
+export default AsyncButton as <T extends React.ElementType = 'button'>(
   props: AsyncButtonProps<T> & { ref?: PolymorphicRef<T> },
-) => React.ReactElement;
+) => React.ReactElement | null;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,16 +2,73 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import makeCancellable from 'make-cancellable-promise';
 
+// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
+// A more precise version of just React.ComponentPropsWithoutRef on its own
+export type PropsOf<C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>> =
+  JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
+
+type AsProp<C extends React.ElementType> = {
+  /**
+   * An override of the default HTML tag.
+   * Can also be another React component.
+   */
+  as?: C;
+};
+
+/**
+ * Allows for extending a set of props (`ExtendedProps`) by an overriding set of props
+ * (`OverrideProps`), ensuring that any duplicates are overridden by the overriding
+ * set of props.
+ */
+export type ExtendableProps<ExtendedProps = unknown, OverrideProps = unknown> = OverrideProps &
+  Omit<ExtendedProps, keyof OverrideProps>;
+
+/**
+ * Allows for inheriting the props from the specified element type so that
+ * props like children, className & style work, as well as element-specific
+ * attributes like aria roles. The component (`C`) must be passed in.
+ */
+export type InheritableElementProps<C extends React.ElementType, Props = unknown> = ExtendableProps<
+  PropsOf<C>,
+  Props
+>;
+
+/**
+ * A more sophisticated version of `InheritableElementProps` where
+ * the passed in `as` prop will determine which props can be included
+ */
+export type PolymorphicComponentProps<
+  C extends React.ElementType,
+  Props = unknown,
+> = InheritableElementProps<C, Props & AsProp<C>>;
+
+/**
+ * Utility type to extract the `ref` prop from a polymorphic component
+ */
+export type PolymorphicRef<C extends React.ElementType> = React.ComponentPropsWithRef<C>['ref'];
+/**
+ * A wrapper of `PolymorphicComponentProps` that also includes the `ref`
+ * prop for the polymorphic component
+ */
+export type PolymorphicComponentPropsWithRef<
+  C extends React.ElementType,
+  Props = unknown,
+> = PolymorphicComponentProps<C, Props> & { ref?: PolymorphicRef<C> };
+
 type Config<T extends React.ElementType> = React.ComponentPropsWithoutRef<T>;
 
-type AsyncButtonProps<T extends React.ElementType> = {
-  as?: T;
+type Props<T extends React.ElementType> = {
   errorConfig?: Config<T>;
   onClick?: (event: React.MouseEvent) => void | Promise<void>;
   pendingConfig?: Config<T>;
   resetTimeout?: number;
   successConfig?: Config<T>;
 } & Config<T>;
+
+type AsyncButtonProps<C extends React.ElementType = 'button'> = PolymorphicComponentPropsWithRef<
+  C,
+  Props<C>
+>;
 
 const STATES = {
   ERROR: 'error',
@@ -31,7 +88,7 @@ const AsyncButton = React.forwardRef(
       successConfig,
       ...otherProps
     }: AsyncButtonProps<T>,
-    ref: React.ForwardedRef<any>,
+    ref?: PolymorphicRef<T>,
   ) => {
     const [buttonState, setButtonState] = useState<typeof STATES[keyof typeof STATES]>(STATES.INIT);
     const cancellablePromise = useRef<ReturnType<typeof makeCancellable>>();
@@ -135,6 +192,6 @@ AsyncButton.propTypes = {
   successConfig: isConfigObject,
 };
 
-export default AsyncButton as <T extends React.ElementType = 'button'>(
-  props: AsyncButtonProps<T> & React.RefAttributes<any>,
-) => React.ReactElement | null;
+export default AsyncButton as <T extends React.ElementType>(
+  props: AsyncButtonProps<T> & { ref?: PolymorphicRef<T> },
+) => React.ReactElement;


### PR DESCRIPTION
Based on Your #66  and after finding https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts.

That should help resolve issues with React.forwardRef  type